### PR TITLE
fix(Toggle):  메인 컨텍스트 초기화되는 현상 해결

### DIFF
--- a/src/components/toggle/index.jsx
+++ b/src/components/toggle/index.jsx
@@ -3,7 +3,7 @@ import styles from './styles.module.css';
 import clsx from 'clsx';
 
 const Toggle = ({ on = false, onClick }) => {
-    const [isOn, setIsOn] = useState(false);
+    const [isOn, setIsOn] = useState(on);
 
     const handleClick = () => {
         setIsOn((prev) => !prev);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import styles from './index.module.css';
@@ -6,24 +6,22 @@ import {
     HomepageFeatures,
     NerdHompageFeatures,
 } from '../components/homepage-feature';
-import { MainContext } from '../context/main-context';
+import { useMainContext } from '../context/main-context';
 import HomepageHeader from '../components/hompage/homepage-header';
 
 export default function Home() {
     const { siteConfig } = useDocusaurusContext();
-    const [isStrict, setIsStrict] = useState(true);
+    const { isStrict } = useMainContext();
 
     return (
-        <MainContext.Provider value={{ isStrict, setIsStrict }}>
-            <Layout
-                title={`Hello from ${siteConfig.title}`}
-                description="FB DEVELO4's BLOG 에 어서오세요! Front 와 BackEnd 기술 문서와 간단한 블로깅을 함께하고 있습니다! <head />"
-            >
-                {isStrict && <HomepageHeader />}
-                <main className={isStrict ? styles.strictMain : styles.main}>
-                    {isStrict ? <HomepageFeatures /> : <NerdHompageFeatures />}
-                </main>
-            </Layout>
-        </MainContext.Provider>
+        <Layout
+            title={`Hello from ${siteConfig.title}`}
+            description="FB DEVELO4's BLOG 에 어서오세요! Front 와 BackEnd 기술 문서와 간단한 블로깅을 함께하고 있습니다! <head />"
+        >
+            {isStrict && <HomepageHeader />}
+            <main className={isStrict ? styles.strictMain : styles.main}>
+                {isStrict ? <HomepageFeatures /> : <NerdHompageFeatures />}
+            </main>
+        </Layout>
     );
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import { MainContext } from '../context/main-context';
+
+// Default implementation, that you can customize
+export default function Root({ children, ...props }) {
+    const [isStrict, setIsStrict] = useState(true);
+    return (
+        <MainContext.Provider value={{ isStrict, setIsStrict }}>
+            {children}
+        </MainContext.Provider>
+    );
+}


### PR DESCRIPTION
## 원인
레이아웃이 마운트될때마다 컨텍스트가 매번 초기화되는 현상이 생김 
또한 페이지마다 특정 컨텍스트가 더 추가되면서 더 상위 프로바이더가 존재하고 새로 마운트되버려 상태초기화가 되기도 함

## 해결 방식
docusaurus에서는 Root 컴포넌트를 만들어 전체 최상위 컴포넌트로 swizzle할 것을 권장 

https://stackoverflow.com/questions/67966163/root-component-swizzle-in-docusaurus-v2-not-working

theme 폴더에 컨텍스트 파일 생성 후 .docusaurus 폴더 삭제 후 재 설치 
적용완료